### PR TITLE
Removed hardcoded 6-digits segment substrings

### DIFF
--- a/bin/segment_gatherer.py
+++ b/bin/segment_gatherer.py
@@ -149,8 +149,8 @@ class SegmentGatherer(object):
             channel_name, segments = itm.split(':')
             segments = segments.split('-')
             if len(segments) > 1:
-                segments = ['%06d' % i for i in range(int(segments[0]),
-                                                          int(segments[-1])+1)]
+                segments = ['%d' % i for i in range(int(segments[0]),
+                                                    int(segments[-1]) + 1)]
             meta['channel_name'] = channel_name
             for seg in segments:
                 meta['segment'] = seg


### PR DESCRIPTION
Some filenames differ from formerly implemented 6-digit scheme.

i.e . Himawari8 files are named like IMG_DK01IR1_201604291009_010 (segment "010")

The configured pattern must be adjusted to handle both cases. For example {segment:0>6s} for 6 digits
and {segment:0>3s} for 3 digits.