### PR TITLE
Stalker support for custom variables

### DIFF
--- a/bin/segment_gatherer.py
+++ b/bin/segment_gatherer.py
@@ -42,6 +42,7 @@ SLOT_READY = 1
 SLOT_READY_BUT_WAIT_FOR_MORE = 2
 SLOT_OBSOLETE_TIMEOUT = 3
 
+DO_NOT_COPY_KEYS = ("uid", "uri", "channel_name", "segment")
 
 class SegmentGatherer(object):
 
@@ -87,7 +88,7 @@ class SegmentGatherer(object):
         # Init metadata struct
         metadata = {}
         for key in msg.data:
-            if key not in ("uid", "uri", "channel_name", "segment"):
+            if key not in DO_NOT_COPY_KEYS:
                 metadata[key] = msg.data[key]
         metadata['dataset'] = []
 
@@ -308,7 +309,14 @@ class SegmentGatherer(object):
         except ValueError:
             self.logger.debug("Unknown file, skipping.")
             return
-        time_slot = str(mda[self.time_name])
+
+        metadata = {}
+        for key in msg.data:
+            if key not in DO_NOT_COPY_KEYS:
+                metadata[key] = msg.data[key]
+        metadata.update(mda)
+
+        time_slot = str(metadata[self.time_name])
 
         # Init metadata etc if this is the first file
         if time_slot not in self.slots:

--- a/examples/trollstalker_config.ini_template
+++ b/examples/trollstalker_config.ini_template
@@ -50,3 +50,28 @@ loglevel=DEBUG
 event_names=IN_CLOSE_WRITE,IN_MOVED_TO
 posttroll_port=0
 alias_platform_name = MSG2:Meteosat-9|MSG3:Meteosat-10
+
+
+[himawari8]
+topic=/H8/topic/or/something/
+directory=/path/to/satellite/data/
+filepattern = {path}IMG_{platform_name:4s}{channel:3s}_{time:%Y%m%d%H%M}_{segment}
+
+# define new variable "platform_name" because it is not included in the filepattern
+var_platform_name = himawari8
+
+# define new datetime variable aligned/ceiled to 15 minutes intervals 
+# (Himawari filename timestampes are not constant for a timeslot)
+var_h8_gather_time={time:%Y%m%d%H%M|align(15)}
+
+# override start_time and end_time because default values are derived from {time} in 
+# filepattern and that is not constant for all files of a timeslot
+# "end_time" should be 1 interval after start_time (3rd parameter of align function)
+var_start_time = {time:%Y%m%d%H%M%S|align(15)}
+var_end_time = {time:%Y%m%d%H%M%S|align(15,0,1)}
+
+instruments = ahi
+stalker_log_config=/usr/local/etc/pytroll/trollstalker_logging.ini
+loglevel=DEBUG
+event_names=IN_CLOSE_WRITE,IN_MOVED_TO
+posttroll_port=0

--- a/trollduction/helper_functions.py
+++ b/trollduction/helper_functions.py
@@ -27,6 +27,8 @@
 import numpy as np
 import os
 import xml_read
+import datetime as dt
+import re
 from mpop.projector import get_area_def
 from pyresample.geometry import Boundary
 import logging
@@ -304,3 +306,100 @@ def overlapping_timeinterval(start_end_times, timelist):
             return tstart, tend
 
     return False
+
+
+def _conv_datetime(stri, convdef, transform):
+    """
+    Convert the string *stri* to the given datetime
+    conversion definition *convdef*.
+    Do some transformation of the parsed data when
+    *transform* is defined
+    """
+    result = dt.datetime.strptime(stri, convdef)
+    if transform:
+        params = _parse_align_time_transform(transform)
+        if params:
+            result = align_time(result,
+                                dt.timedelta(minutes=params[0]),
+                                dt.timedelta(minutes=params[1]),
+                                params[2])
+    return result
+
+
+def create_aligned_datetime_var(var_pattern, info_dict):
+    """
+    uses *var_patterns* like "{time:%Y%m%d%H%M|align(15)}"
+    to new datetime including support for temporal
+    alignment (Ceil/Round a datetime object to a multiple of a timedelta.
+    Useful to equalize small time differences in name of files
+    belonging to the same timeslot)
+    """
+    mtch = re.match(
+        '{(.*?)(!(.*?))?(\\:(.*?))?(\\|(.*?))?}',
+        var_pattern)
+    
+    if mtch is None:
+        return None
+        
+    # parse date format pattern
+    key = mtch.groups()[0]
+    format_spec = mtch.groups()[4]
+    transform = mtch.groups()[6]
+    date_val = info_dict[key]
+    
+    if not isinstance(date_val, dt.datetime):
+        return None
+    
+    # only for datetime types
+    res = date_val
+    if transform:
+        align_params = _parse_align_time_transform(transform)
+        if align_params:
+            res = align_time(
+                date_val,
+                dt.timedelta(minutes=align_params[0]),
+                dt.timedelta(minutes=align_params[1]),
+                align_params[2])
+    
+    if res is None:
+        # fallback to default compose when no special handling needed
+        res = compose(var_val, self.info) 
+                
+    return res
+
+
+def _parse_align_time_transform(transform_spec):
+    """
+    Parse the align-time transformation string "align(15,0,-1)"
+    and returns *(steps, offset, intv_add)*
+    """
+    match = re.search('align\\((.*)\\)', transform_spec)
+    if match:
+        al_args = match.group(1).split(',')
+        steps = int(al_args[0])
+        if len(al_args) > 1:
+            offset = int(al_args[1])
+        else:
+            offset = 0
+        if len(al_args) > 2:
+            intv_add = int(al_args[2])
+        else:
+            intv_add = 0
+        return (steps, offset, intv_add)
+    else:
+        return None
+
+
+def align_time(input_val, steps=dt.timedelta(minutes=5),
+               offset=dt.timedelta(minutes=0), intervals_to_add=0):
+    """
+    Ceil/Round a datetime object to a multiple of a timedelta.
+    Useful to equalize small time differences in name of files
+    belonging to the same timeslot
+    """
+    stepss = steps.total_seconds()
+    val = input_val - offset
+    vals = (val - val.min).seconds
+    result = val - dt.timedelta(seconds=(vals - (vals // stepss) * stepss))
+    result = result + (intervals_to_add * steps)
+    return result

--- a/trollduction/tests/test_helper_functions.py
+++ b/trollduction/tests/test_helper_functions.py
@@ -24,8 +24,9 @@
 """
 
 import unittest
-from trollduction.helper_functions import overlapping_timeinterval
-from datetime import datetime, timedelta
+from datetime import datetime
+
+from trollduction.helper_functions import overlapping_timeinterval, create_aligned_datetime_var
 
 
 class TestTimeUtilities(unittest.TestCase):
@@ -67,6 +68,83 @@ class TestTimeUtilities(unittest.TestCase):
                     ]
         retv = overlapping_timeinterval((dt_start, dt_end), timelist)
         self.assertTrue(retv is False)
+
+
+    def test_create_aligned_datetime_var(self):
+        """Test the create_aligned_datetime_var function"""
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(5)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 17, 10, 48)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 10, 0))
+
+        # Run
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 17, 3, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 0, 0))
+
+        # Run
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 16, 55, 0))
+
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15)}"
+
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 16, 45, 0))
+
+    def test_create_aligned_datetime_var_offsets(self):
+        """Test the create_aligned_datetime_var function"""
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15,-2)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 0, 0))
+
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15,2)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 17, 16, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 0, 0))
+
+    def test_parse_time_with_timeslot_aligment_intervals_add(self):
+        """Test the create_aligned_datetime_var function"""
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15,0,1)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 0, 0))
+
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15,0,2)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 17, 15, 0))
+
+        # Run
+        filepattern = "{start_time:%Y%m%d%H%M%S|align(15,0,-1)}"
+        result = create_aligned_datetime_var(filepattern,
+                                             {'start_time':
+                                              datetime(2015, 1, 9, 16, 59, 0)})
+        # Assert
+        self.assertEqual(result, datetime(2015, 1, 9, 16, 30, 0))
 
     def tearDown(self):
         """Closing down


### PR DESCRIPTION
.. for Datetime format spec with temporal alignment

Support for format specifications like {start_time:%Y%m%d%H%M%S|align(5)}
to ceil/round a datetime to a multiple of a timedelta.
Useful to equalize small time differences in name of files belonging to the same timeslot
The first parameter represents the difference between timeslots in minutes.

Example config:

[trollstalker]
...
var_gatherer_time={time:%Y%m%d%H%M|align(15)}
...
This creates a new posttroll message dict entry "gatherer_time" with a datetime object ceiled
to 15 minutes intervals.

align(5):
17:10:58 -> 17:10:00
17:03:00 -> 17:00:00
16:59:00 -> 16:55:00

align(15):
16:59:00 -> 16:45:00

When called with two arguments, the second denote a kind of offset subtracted before ceiling (default: 0).

align(15,-2):
16:59:00 -> 17:00:00

align(15,2):
17:16:00 -> 17:00:00

When called with three arguments, the specified number of intervals (defined by argument 1) will be added to
the result.

align(15,0,1):
16:59:00 -> 17:00:00

align(15,0,2):
16:59:00 -> 17:15:00

align(15,0,-1):
16:59:00 -> 16:30:00