### PR TITLE
Nameserver definition for stalker, segment_gatherer + l2processor

### DIFF
--- a/bin/segment_gatherer.py
+++ b/bin/segment_gatherer.py
@@ -53,8 +53,10 @@ class SegmentGatherer(object):
         self._config = config
         self._section = section
         topics = config.get(section, 'topics').split()
+        nameservers = config.get(section, 'nameservers').split()
         self._listener = ListenerContainer(topics=topics)
-        self._publisher = publisher.NoisyPublisher("segment_gatherer")
+        self._publisher = publisher.NoisyPublisher("segment_gatherer",
+                                                   nameservers=nameservers)
         self._subject = config.get(section, "publish_topic")
         self._pattern = config.get(section, 'pattern')
         self._parser = Parser(self._pattern)

--- a/bin/segment_gatherer.py
+++ b/bin/segment_gatherer.py
@@ -53,7 +53,13 @@ class SegmentGatherer(object):
         self._config = config
         self._section = section
         topics = config.get(section, 'topics').split()
-        nameservers = config.get(section, 'nameservers').split()
+        
+        try:
+            nameservers = config.get(section, 'nameservers')
+            nameservers = nameservers.split(',')
+        except (NoOptionError, ValueError):
+            nameservers = []
+        
         self._listener = ListenerContainer(topics=topics)
         self._publisher = publisher.NoisyPublisher("segment_gatherer",
                                                    nameservers=nameservers)

--- a/bin/trollstalker.py
+++ b/bin/trollstalker.py
@@ -57,10 +57,11 @@ class EventHandler(ProcessEvent):
 
     def __init__(self, topic, instrument, posttroll_port=0, filepattern=None,
                  aliases=None, tbus_orbit=False, history=0, granule_length=0,
-                 custom_vars=None):
+                 custom_vars=None, nameservers=[]):
         super(EventHandler, self).__init__()
 
-        self._pub = NoisyPublisher("trollstalker", posttroll_port, topic)
+        self._pub = NoisyPublisher("trollstalker", posttroll_port, topic,
+                                   nameservers=nameservers)
         self.pub = self._pub.start()
         self.topic = topic
         self.info = OrderedDict()
@@ -224,7 +225,7 @@ class NewThreadedNotifier(ThreadedNotifier):
 def create_notifier(topic, instrument, posttroll_port, filepattern,
                     event_names, monitored_dirs, aliases=None,
                     tbus_orbit=False, history=0, granule_length=0,
-                    custom_vars=None):
+                    custom_vars=None, nameservers=[]):
     '''Create new notifier'''
 
     # Event handler observes the operations in defined folder
@@ -247,7 +248,8 @@ def create_notifier(topic, instrument, posttroll_port, filepattern,
                                  tbus_orbit=tbus_orbit,
                                  history=history,
                                  granule_length=granule_length,
-                                 custom_vars=custom_vars)
+                                 custom_vars=custom_vars,
+                                 nameservers=nameservers)
 
     notifier = NewThreadedNotifier(manager, event_handler)
 
@@ -347,6 +349,10 @@ def main():
     parser.add_argument("-i", "--instrument",
                         type=str, default=None,
                         help="Instrument name in the satellite")
+    parser.add_argument("-n", "--nameservers",
+                        type=str, default=None,
+                        help="Posttroll nameservers to register own address,"
+                        " otherwise multicasting is used")
 
     if len(sys.argv) <= 1:
         parser.print_help()
@@ -366,6 +372,7 @@ def main():
     topic = args.topic
     event_names = args.event_names
     instrument = args.instrument
+    nameservers = args.nameservers
 
     filepattern = args.filepattern
     if args.filepattern == '':
@@ -409,6 +416,8 @@ def main():
         except KeyError:
             history = 0
 
+        nameservers = nameservers or config['nameservers']
+
         aliases = parse_aliases(config)
         tbus_orbit = bool(config.get("tbus_orbit", False))
 
@@ -444,12 +453,18 @@ def main():
     if type(monitored_dirs) is not list:
         monitored_dirs = [monitored_dirs]
 
+    if nameservers:
+        nameservers = nameservers.split(',')
+    else:
+        nameservers = []
+
     # Start watching for new files
     notifier = create_notifier(topic, instrument, posttroll_port, filepattern,
                                event_names, monitored_dirs, aliases=aliases,
                                tbus_orbit=tbus_orbit, history=history,
                                granule_length=granule_length,
-                               custom_vars=custom_vars)
+                               custom_vars=custom_vars,
+                               nameservers=nameservers)
     notifier.start()
 
     try:

--- a/examples/l2processor_config.ini_template
+++ b/examples/l2processor_config.ini_template
@@ -15,3 +15,9 @@ td_log_config=/usr/local/etc/pytroll/trollduction_logging.ini
 # option below, so that only first of identical consecutive messages
 #  will be processed
 # process_only_once=True
+
+# nameserver hosts to register publisher
+# WARNING: 
+# if nameservers option is set, address broadcasting via multicasting is not used any longer.
+# The corresponding nameserver has to be started with command line option "--no-multicast".
+#nameservers=localhost

--- a/examples/segment_gatherer.ini_template
+++ b/examples/segment_gatherer.ini_template
@@ -21,6 +21,12 @@ time_name = start_time
 # segments of the same time slot
 variable_tags = proctime,proc_decimal
 
+# nameserver hosts to register publisher
+# WARNING: 
+# if nameservers option is set, address broadcasting via multicasting is not used any longer.
+# The corresponding nameserver has to be started with command line option "--no-multicast".
+#nameservers=localhost
+
 [ears-pps]
 pattern = W_XX-EUMETSAT-Darmstadt,SING+LEV+SAT,{orig_platform_name}+{segment}_C_EUMS_{nominal_time:%Y%m%d%H%M%S}_{orbit_number:5d}.nc
 critical_files = 

--- a/examples/trollstalker_config.ini_template
+++ b/examples/trollstalker_config.ini_template
@@ -32,6 +32,12 @@ event_names=IN_CLOSE_WRITE,IN_MOVED_TO
 # free port.
 posttroll_port=0
 
+# nameserver hosts to register publisher
+# WARNING: 
+# if nameservers option is set, address broadcasting via multicasting is not used any longer.
+# The corresponding nameserver has to be started with command line option "--no-multicast".
+#nameservers=localhost
+
 # use an alias to convert from platform in the filename to OSCAR naming
 alias_platform_name = noaa18:NOAA-18|noaa19:NOAA-19
 

--- a/trollduction/producer.py
+++ b/trollduction/producer.py
@@ -393,13 +393,14 @@ class DataProcessor(object):
     """Process the data.
     """
 
-    def __init__(self, publish_topic=None, port=0):
+    def __init__(self, publish_topic=None, port=0, nameservers=[]):
         self.global_data = None
         self.local_data = None
         self.product_config = None
         self._publish_topic = publish_topic
         self._data_ok = True
-        self.writer = DataWriter(publish_topic=self._publish_topic, port=port)
+        self.writer = DataWriter(publish_topic=self._publish_topic, port=port,
+                                 nameservers=nameservers)
         self.writer.start()
 
     def set_publish_topic(self, publish_topic):
@@ -1084,11 +1085,12 @@ class DataWriter(Thread):
     we don't want to block processing.
     """
 
-    def __init__(self, publish_topic=None, port=0):
+    def __init__(self, publish_topic=None, port=0, nameservers=[]):
         Thread.__init__(self)
         self.prod_queue = Queue.Queue()
         self._publish_topic = publish_topic
         self._port = port
+        self._nameservers = nameservers
         self._loop = True
 
     def set_publish_topic(self, publish_topic):
@@ -1097,7 +1099,8 @@ class DataWriter(Thread):
 
     def run(self):
         """Run the thread."""
-        with Publish("l2producer", port=self._port) as pub:
+        with Publish("l2producer", port=self._port,
+                     nameservers=self._nameservers) as pub:
             umask = os.umask(0)
             os.umask(umask)
             default_mode = int('666', 8) - umask
@@ -1258,9 +1261,12 @@ class Trollduction(object):
             self.td_config = config
             self.update_td_config()
 
+        nameservers = self.td_config.get('nameservers','').split(',')
+
         self.data_processor = \
             DataProcessor(publish_topic=self.td_config.get('publish_topic'),
-                          port=int(self.td_config.get('port', 0)))
+                          port=int(self.td_config.get('port', 0)),
+                          nameservers=nameservers)
 
     def update_td_config_from_file(self, fname, config_item=None):
         '''Read Trollduction config file and use the new parameters.


### PR DESCRIPTION
New parameter in configuration file. i.e.:

nameservers=localhost

It defines the nameserver hosts to register publishers of trollstalker, segment_gatherer and l2processor
WARNING:
If nameservers option is set, address broadcasting via multicasting is not used any longer.
The corresponding nameserver has to be started with command line option "--no-multicast".