### PR TITLE
Share product_config between multiple l2processors

### DIFF
--- a/bin/l2processor.py
+++ b/bin/l2processor.py
@@ -25,6 +25,7 @@
 ./l2processor.py -c /path/to/master_config.ini -C noaa_hrpt
 """
 
+from tempfile import mkstemp
 from trollduction.producer import Trollduction
 import argparse
 import logging
@@ -34,6 +35,30 @@ import signal
 import sys
 import os
 import time
+
+
+def create_instance_log_config(orig_log_config, process_num):
+    '''
+    Creates a copy of the log config file and replaces
+    all occurencies of "%PROCNUM%" with the specified
+    *process_num*. Can be used to ensure that multiple instances
+    of l2processors write to own log files but share the same
+    log config file
+    '''
+    _, temp_file = mkstemp()
+    try:
+        with open(orig_log_config) as infile:
+            with open(temp_file, 'w') as outfile:
+                replacements = {'%PROCNUM%': '{0:02d}'.format(process_num)}
+                for line in infile:
+                    for src, target in replacements.iteritems():
+                        line = line.replace(src, target)
+                    outfile.write(line)
+    except:
+        os.remove(temp_file)
+        raise
+    return temp_file
+
 
 if __name__ == '__main__':
 
@@ -46,6 +71,11 @@ if __name__ == '__main__':
                         type=str,
                         default='',
                         help="The item in the file with configuration.")
+    parser.add_argument("-N", "--process_num", dest="process_num",
+                        type=int,
+                        default=None,
+                        help="the process number used to assign workload "
+                        "from product configuration")
 
     args = parser.parse_args()
 
@@ -73,7 +103,16 @@ if __name__ == '__main__':
     except NoOptionError:
         logging.basicConfig()
     else:
-        logging.config.fileConfig(log_config)
+        if args.process_num is None:
+            logging.config.fileConfig(log_config,
+                                      disable_existing_loggers=False)
+        else:
+            inst_log_config = create_instance_log_config(log_config,
+                                                         args.process_num)
+            logging.config.fileConfig(inst_log_config,
+                                      disable_existing_loggers=False)
+            if os.path.exists(inst_log_config):
+                os.remove(inst_log_config)
 
     logger = logging.getLogger("trollduction")
 
@@ -81,6 +120,7 @@ if __name__ == '__main__':
     cfg = dict(config.items(args.config_item))
     cfg["config_item"] = args.config_item
     cfg["config_file"] = args.config_file
+    cfg["process_num"] = args.process_num
     if "timezone" in cfg:
         print "Setting timezone to %s" % cfg["timezone"]
         os.environ["TZ"] = cfg["timezone"]

--- a/examples/product_config_hrit.xml_template
+++ b/examples/product_config_hrit.xml_template
@@ -60,6 +60,28 @@
                 <file output_dir="path2">{platform_name}_{time:%Y%m%d_%H%M}_{areaname}_{productname}.png</file>
             </product>
         </area>
+        
+        <!-- 
+        Example on how to use same product_config.xml with multiple parellel running l2processor instances:
+            1. Start l2processor with additional argument "-N <PROCNUM>" (PROCNUM should be an int value).
+            2. Add attribute "process_num" to <area> elements in product_config.xml to assign l2processor instance to an area
+               that it should process.
+            3. If the logger.ini should be shared between l2processor instances, use "%PROCNUM%" in configured log filenames. 
+               It will be replaced by the assigned PROCNUM at runtime when l2processor starts.    
+        -
+        <!-- area should only processed by l2processor instance 1 (started with arg "-N 1") -->
+        <area id="euron1" name="North europe, 1km/pixel" process_num="1">
+            <product id="ir108" name="ir108">
+                <file output_dir="path2">{platform_name}_{time:%Y%m%d_%H%M}_{areaname}_{productname}.png</file>
+            </product>
+        </area>
+        <!-- area should only processed by l2processor instance 2 (started with arg "-N 2") -->
+        <area id="euron1" name="North europe, 1km/pixel" process_num="1">
+            <product id="ir108" name="ir108">
+                <file output_dir="path2">{platform_name}_{time:%Y%m%d_%H%M}_{areaname}_{productname}.png</file>
+            </product>
+        </area>
+        
     </product_list>
 </product_config>
 


### PR DESCRIPTION
Allows to assign certain areas in product_config.xml to parallel running l2processor instances.

Configuration steps:
1. Start l2processor with additional argument "-N <PROCNUM>" (PROCNUM should be an int value, i.e. 0, 1,...).
2. Add attribute "process_num" to <area> elements in product_config.xml to assign l2processor instance to an area that it should process.
3. If the logger.ini should be shared between l2processor instances, use "%PROCNUM%" in configured log filenames. It will be replaced by the assigned PROCNUM at runtime when l2processor starts.