### PR TITLE
Use end_time if available for creating scene

### DIFF
--- a/trollduction/producer.py
+++ b/trollduction/producer.py
@@ -439,6 +439,10 @@ class DataProcessor(object):
         time_slot = (mda.get('start_time') or
                      mda.get('nominal_time') or
                      mda.get('end_time'))
+        
+        scene_time_slot = time_slot
+        if 'end_time' in mda:
+            scene_time_slot = (scene_time_slot, mda['end_time'])
 
         # orbit is not given for GEO satellites, use None
 
@@ -459,7 +463,7 @@ class DataProcessor(object):
         global_data = GF.create_scene(satname=str(platform),
                                       satnumber='',
                                       instrument=str(sensor),
-                                      time_slot=time_slot,
+                                      time_slot=scene_time_slot,
                                       orbit=mda['orbit_number'],
                                       variant=mda.get('variant', ''))
         LOGGER.debug("Creating scene for satellite %s and time %s",


### PR DESCRIPTION
If "end_time" was found in posttroll message (created by trollstalker),
the tuple (time, end_time) is used to create the scene. This is necessary
to read all segments of an Himawari8 dataset.