### PR TITLE
Allow muliple area elements with same id in config

### DIFF
--- a/trollduction/tests/test_xml_read.py
+++ b/trollduction/tests/test_xml_read.py
@@ -91,6 +91,19 @@ xmlstuff = """<?xml version="1.0" encoding='utf-8'?>
       </product>
 
     </area>
+
+    <!-- same area but with different product list -->
+    <area id="nsea" name="North_Baltic_Sea">
+        <product id="night_fog" name="night_fog" sunzen_night_minimum="90" sunzen_lonlat="25, 60">
+            <file>{time:%Y%m%d_%H%M}_{platform}{satnumber}_{areaname}_{composite}.png</file>
+          </product>
+    </area>
+    <area id="nsea" name="North_Baltic_Sea">
+        <product id="night_overview" name="night_overview" sunzen_night_minimum="90" sunzen_lonlat="25, 60">
+            <file format="png">{time:%Y%m%d_%H%M}_{platform}{satnumber}_{areaname}_{composite}.png</file>
+        </product>
+    </area>
+
   </product_list>
 </product_config>
 """
@@ -121,6 +134,18 @@ class TestProductList(unittest.TestCase):
                            'format_params': {'nbits': '8',
                                              'fill_value_subst': '1'}
                            })
+
+    def test_duplicate_areas(self):
+        group = self.pconfig.groups[0]
+        self.assertEquals(len(group.data), 3)
+        self.assertEquals(group.data[0].attrib.get('id'), 'eurol')
+        self.assertEquals(group.data[1].attrib.get('id'), 'nsea')
+        self.assertEquals(group.data[1].find('product').attrib.get('id'),
+                          'night_fog')
+        self.assertEquals(group.data[2].attrib.get('id'), 'nsea')
+        self.assertEquals(group.data[2].find('product').attrib.get('id'),
+                          'night_overview')
+        group.data[0]
 
 
 def suite():

--- a/trollduction/xml_read.py
+++ b/trollduction/xml_read.py
@@ -116,14 +116,16 @@ class ProductList(object):
 
         # replace area ids with actual xml area items
         groups = []
+        tempprodlist = list(self.prodlist)
         for group in self.groups:
             new_group = Dataset([], **group.info)
             for area_id in group.data:
                 assigned = False
-                for area in self.prodlist:
+                for area in tempprodlist:
                     if area.attrib["id"] == area_id:
                         new_group.data.append(area)
                         assigned = True
+                        tempprodlist.remove(area)
                         break
                 if not assigned:
                     LOGGER.warning("Couldn't find area %s in product list",


### PR DESCRIPTION
To support products within same areas assigned to different l2processor instances, it must be possible to use area elements with same id but different process_number attribute.
 
For example, two l2processors share config and should process the same area but different products:
```
   <area id="nsea" name="North_Baltic_Sea" process_num="0">
        <product id="night_fog" name="night_fog">
            <file>{time:%Y%m%d_%H%M}_{platform}{satnumber}_{areaname}_{composite}.png</file>
          </product>
    </area>
    <area id="nsea" name="North_Baltic_Sea" process_num="1">
        <product id="night_overview" name="night_overview">
            <file format="png">{time:%Y%m%d_%H%M}_{platform}{satnumber}_{areaname}_{composite}.png</file>
        </product>
    </area>
```